### PR TITLE
[Review] Add support for head handling head request

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -19,6 +19,15 @@ func (c Controller) Get(path string, f func(http.ResponseWriter, *http.Request) 
 	c.router.Get(path, c.chain.ThenFunc(ResponseHandler(f)))
 }
 
+//Head returns HEAD handler function
+func (c Controller) Head(path string, body interface{}, f func(http.ResponseWriter, *http.Request) Response) {
+	if body == nil {
+		c.router.Head(path, c.chain.ThenFunc(ResponseHandler(f)))
+	} else {
+		c.router.Head(path, c.chain.Append(JSONBodyHandler(c.ctx, body)).ThenFunc(ResponseHandler(f)))
+	}
+}
+
 //Post returns POST handler function
 func (c Controller) Post(path string, body interface{}, f func(http.ResponseWriter, *http.Request) Response) {
 	if body == nil {

--- a/controller.go
+++ b/controller.go
@@ -20,12 +20,8 @@ func (c Controller) Get(path string, f func(http.ResponseWriter, *http.Request) 
 }
 
 //Head returns HEAD handler function
-func (c Controller) Head(path string, body interface{}, f func(http.ResponseWriter, *http.Request) Response) {
-	if body == nil {
-		c.router.Head(path, c.chain.ThenFunc(ResponseHandler(f)))
-	} else {
-		c.router.Head(path, c.chain.Append(JSONBodyHandler(c.ctx, body)).ThenFunc(ResponseHandler(f)))
-	}
+func (c Controller) Head(path string, f func(http.ResponseWriter, *http.Request) Response) {
+	c.router.Head(path, c.chain.ThenFunc(ResponseHandler(f)))
 }
 
 //Post returns POST handler function

--- a/router.go
+++ b/router.go
@@ -183,6 +183,11 @@ func (s *PhilRouter) Get(path string, handler http.Handler) {
 	}
 }
 
+// Head wraps httprouter's HEAD function
+func (s *PhilRouter) Head(path string, handler http.Handler) {
+	s.r.HEAD(path, wrapHandler(s.Ctx, handler))
+}
+
 // Post wraps httprouter's POST function
 func (s *PhilRouter) Post(path string, handler http.Handler) {
 	s.r.POST(path, wrapHandler(s.Ctx, handler))


### PR DESCRIPTION
Adding support for handling head request. Mandrill webhook uses HEAD request to handle verification of end points.

https://app.asana.com/0/406568776885776/1200353903259080/f