### PR TITLE
Set error status code for error API response

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -269,7 +269,7 @@ func MetricsHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-//ContentTypeHandler make sure content type is appplication/json for PUT/POST data
+// ContentTypeHandler make sure content type is appplication/json for PUT/POST data
 func ContentTypeHandler(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Content-Type") != "application/json" {
@@ -288,6 +288,19 @@ func WriteJSON(w http.ResponseWriter, resource interface{}) {
 	w.Header().Set("X-Host-Id", hostName)
 
 	err := json.NewEncoder(w).Encode(resource)
+	if err != nil {
+		logger.Errorf("Error writing JSON: %s", err)
+		WriteError(w, ErrInternalServer)
+		return
+	}
+}
+
+func WriteErrorJSON(w http.ResponseWriter, e *Error, resources interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(e.Status)
+	w.Header().Set("X-Host-Id", hostName)
+
+	err := json.NewEncoder(w).Encode(resources)
 	if err != nil {
 		logger.Errorf("Error writing JSON: %s", err)
 		WriteError(w, ErrInternalServer)

--- a/router.go
+++ b/router.go
@@ -197,6 +197,9 @@ type APIResponse struct {
 func (res APIResponse) Write(w http.ResponseWriter, r *http.Request) {
 	if res.Status == "ERROR" {
 		logger.Errorf("[API][PATH: %s]:: Error handling request. ERROR: %s. User agent: %s", r.RequestURI, res.Error, r.Header.Get("User-Agent"))
+		// Patch to fix API returning 200 on error response, but will always return 500 regardless of the error
+		WriteErrorJSON(w, ErrInternalServer, res)
+		return
 	}
 	WriteJSON(w, res)
 }


### PR DESCRIPTION
> Patch to fix API returning 200 on error response
- NOT good solution as it will always return 500 regardless of the error
- Another solution could be to add `HttpStatus` attribute in `APIResponse` allowing controllers to set status code.