### PR TITLE
Change Error API response to handle logging

### DIFF
--- a/router.go
+++ b/router.go
@@ -186,17 +186,37 @@ func (res CSVResponse) Write(w http.ResponseWriter, r *http.Request) {
 	w.Write(res.CSV)
 }
 
-// APIResponse response data representation for API
+type ErrorData struct {
+	LogType LogType
+}
+
+type LogType string
+
+const (
+	LogTypeInfo    LogType = "INFO"
+	LogTypeWarning LogType = "WARNING"
+	LogTypeError   LogType = "ERROR"
+)
+
+// APIResponse is the response data representation for API
 type APIResponse struct {
 	Error  string      `json:"error,omitempty"`
 	Status string      `json:"status,omitempty"`
 	Data   interface{} `json:"data,omitempty"`
+	Type   LogType     `json:"type,omitempty"`
 }
 
 // Write - Reponse interface implementation
 func (res APIResponse) Write(w http.ResponseWriter, r *http.Request) {
 	if res.Status == "ERROR" {
-		logger.Errorf("[API][PATH: %s]:: Error handling request. ERROR: %s. User agent: %s", r.RequestURI, res.Error, r.Header.Get("User-Agent"))
+		switch res.Type {
+		case LogTypeInfo:
+			logger.Infof("Info Message")
+		case LogTypeWarning:
+			logger.Warnf("Warning Message")
+		default:
+			logger.Errorf("[API][PATH: %s]:: Error handling request. ERROR: %s. User agent: %s", r.RequestURI, res.Error, r.Header.Get("User-Agent"))
+		}
 	}
 	WriteJSON(w, res)
 }


### PR DESCRIPTION
### Description of Change

- Added LogType as "INFO" and "WARNING" to log the messages accordingly in Grafana
- For every ErrorResponse in API Calls, the error will also be logged in Grafana as either Info or Warning or as an Error. 